### PR TITLE
Ubiquity post not rendering on newer versions of Hugo

### DIFF
--- a/content/event/20190219-Ubiquity-Robotics-1.md
+++ b/content/event/20190219-Ubiquity-Robotics-1.md
@@ -4,7 +4,7 @@ description = ""
 tags = ["workshop", "pod havbo", "delavnice", "robots", "ROS", "Ubiquity Robotics"]
 title = "Workshop: So you want to build robots? (2 Days)"
 linkrsvp = ""
-
+publishdate="2019-02-11"
 +++
 **When**: Feb. 19 and Feb. 20, 17:00 - 20:00 (2 Day workshop)
 


### PR DESCRIPTION
Enables newer versions of Hugo (e.g. v0.54.0) to render the Ubiquity event.

Hugo introduced a new `publishdate` field which if left unset will default to the `date` field. The `date` field in this website is used as the date of the event - which will of course often be in the future. This interferes (in newer versions of Hugo) with the rendering of the page since it's set to be published in the future.
  
For more details, see [here](https://github.com/gohugoio/hugo/issues/3977#issuecomment-338460196).